### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,44 @@
 {
-    "name" : "grunt-archive-diff",
-    "description" : "A Grunt plugin to export a git diff archive.",
-    "version" : "0.1.0",
-    "homepage" : "https://github.com/WitteStier/grunt-archive-diff",
-    "author" : {
-        "name" : "WitteStier",
-        "email" : "development@wittestier.nl"
+    "name": "grunt-archive-diff",
+    "description": "A Grunt plugin to export a git diff archive.",
+    "version": "0.1.0",
+    "homepage": "https://github.com/WitteStier/grunt-archive-diff",
+    "author": {
+        "name": "WitteStier",
+        "email": "development@wittestier.nl"
     },
-    "repository" : {
-        "type" : "git",
-        "url" : "https://github.com/WitteStier/grunt-archive-diff.git"
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/WitteStier/grunt-archive-diff.git"
     },
-    "bugs" : {
-        "url" : "https://github.com/WitteStier/grunt-archive-diff/issues"
+    "bugs": {
+        "url": "https://github.com/WitteStier/grunt-archive-diff/issues"
     },
-    "licenses" : [
+    "licenses": [
         {
-            "type" : "MIT",
-            "url" : "https://github.com/WitteStier/grunt-archive-diff/blob/master/LICENSE-MIT"
+            "type": "MIT",
+            "url": "https://github.com/WitteStier/grunt-archive-diff/blob/master/LICENSE-MIT"
         }
     ],
-    "engines" : {
-        "node" : ">= 0.8.0"
+    "engines": {
+        "node": ">= 0.8.0"
     },
-    "scripts" : {
-        "test" : "grunt test"
+    "scripts": {
+        "test": "grunt test"
     },
-    "dependencies" : {
-        "async" : "~0.2.9"
+    "dependencies": {
+        "async": "~0.2.9"
     },
-    "devDependencies" : {
-        "grunt-contrib-jshint" : "^0.9.2",
-        "grunt-contrib-clean" : "^0.5.0",
-        "grunt-contrib-nodeunit" : "^0.3.3",
-        "grunt" : "~0.4.5"
+    "devDependencies": {
+        "grunt-contrib-jshint": "^0.9.2",
+        "grunt-contrib-clean": "^0.5.0",
+        "grunt-contrib-nodeunit": "^0.3.3",
+        "grunt": "~0.4.5"
     },
-    "peerDependencies" : {
-        "grunt" : "~0.4.5"
+    "peerDependencies": {
+        "grunt": ">=0.4.0"
     },
-    "keywords" : [
+    "keywords": [
         "gruntplugin"
     ]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
